### PR TITLE
Small awork community service improvement

### DIFF
--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -93,6 +93,7 @@ export default {
       ":host:/projects/:project/tasks/timeline/\\(detailModal\\::id/details\\)",
       ":host:/tasks/:id/details",
       ":host:/tasks/filters/\\(detail\\::id/details\\)",
+      ":host:/tasks/filters/:filterId/\\(detail\\::id/details\\)",
       ":host:/my/dashboard/\\(detailModal\\::id/details\\)",
     ],
     projectId: (document) => {


### PR DESCRIPTION
Small fix for the awork community service:
Adds an additional urlPattern to support the Moco browser extension in tasks opened via taskviews, i.e. `https://subdomain.awork.com/tasks/filters/3793f6cd-f958-42b0-a10a-150888f3afa9/(detail:418cadf6-7c8a-4a4a-bab5-1605edced541/details)`

Thanks a lot!