### PR TITLE
Update Gitlab remote service to support new and old look to correctly read title

### DIFF
--- a/src/js/remoteServicesCommunity.js
+++ b/src/js/remoteServicesCommunity.js
@@ -11,7 +11,7 @@ export default {
       ":host:/:org(/*)/:projectId/-/merge_requests/:id(#note_:noteId)",
     ],
     description: (document, service, { id, noteId: _noteId }) => {
-      const title = document.querySelector(".detail-page-description .title")?.textContent?.trim()
+      const title = document.querySelector("h1")?.textContent?.trim()
       return `#${id} ${title || ""}`.trim()
     },
     allowHostOverride: true,


### PR DESCRIPTION
Gitlab changed its UI with an update lately which breaks the title selection via classes. Updating the selector to use h1 instead supports both the old and new UI.